### PR TITLE
Moved @type deps to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "kafka"
   ],
   "dependencies": {
-    "@types/bluebird": "3.5.0",
-    "@types/lodash": "^4.14.55",
     "bin-protocol": "^3.1.1",
     "bluebird": "^3.3.3",
     "buffer-crc32": "^0.2.5",
@@ -33,6 +31,8 @@
     "wrr-pool": "^1.0.3"
   },
   "devDependencies": {
+    "@types/bluebird": "3.5.0",
+    "@types/lodash": "^4.14.55",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "dockerode": "^2.5.7",


### PR DESCRIPTION
Hey!
We're using this dependency in one of our projects, and we came to realize that once we install it our types break. This is because we use lodash, and once installing yes-kafka it also installs type definitions for lodash as well, which break our typescript compiler.

In order to circumvent that, I've moved all @type deps to devDependencies. Type definitions should not be under regular deps for that exact reason - they can clash with the host application's configuration and type dependencies :)